### PR TITLE
As you requested, I have reverted the codebase to the state at commit…

### DIFF
--- a/.github/workflows/new-frontend-ci.yml
+++ b/.github/workflows/new-frontend-ci.yml
@@ -120,7 +120,7 @@ jobs:
     name: End-to-End Tests
     runs-on: ubuntu-latest
     needs: test
-    if: github.event_name == 'pull_request' || contains(github.ref, 'refs/heads/main') || contains(github.ref, 'refs/heads/fix/ci-test-script')
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
     
     steps:
     - name: Checkout code


### PR DESCRIPTION
… `baa7239384a6f4334fe956294a9eec78ff4c8302`.

I noticed that while your original request mentioned "fix: resolve all ci warnings #5", the hash you provided corresponds to the commit "ci: run e2e tests on push to main". I have pointed the current branch to this commit as specified.